### PR TITLE
feat: Ligatures with WebGL

### DIFF
--- a/app/addons/AddonsProvider.ts
+++ b/app/addons/AddonsProvider.ts
@@ -34,8 +34,7 @@ export default class AddonsProvider {
      */
     private setupAddon(config: IConfig, terminal: XTerminal, addon: Addon) {
 
-        if((addon.type !== AddonType.WEBGL || config.webGlRendering) &&
-           (addon.type !== AddonType.LIGATURES || config.fontLigatures)) {
+        if(addon.type !== AddonType.LIGATURES || config.fontLigatures) {
 
             addon.addon = this.resolveAddonFromType(addon.type);
             addon.loaded = true;

--- a/common/config/defaultConfig.ts
+++ b/common/config/defaultConfig.ts
@@ -126,7 +126,7 @@ export const defaultConfig: IConfig = {
     defaultShell,
     shells,
     webGlRendering: true,
-    fontLigatures: false,
+    fontLigatures: true,
     copyOnSelected: true,
     restoreWindowPosition: true,
     tabsIcons: true,

--- a/package.json
+++ b/package.json
@@ -43,11 +43,11 @@
     "ssh2": "^0.8.9",
     "sudo-prompt": "^9.2.1",
     "v8-compile-cache": "^2.2.0",
-    "xterm": "^4.11.0",
+    "xterm": "^4.12.0",
     "xterm-addon-fit": "^0.5.0",
     "xterm-addon-unicode11": "^0.2.0",
     "xterm-addon-web-links": "^0.4.0",
-    "xterm-addon-webgl": "^0.10.0"
+    "xterm-addon-webgl": "^0.11.0"
   },
   "devDependencies": {
     "@babel/preset-react": "^7.12.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11410,15 +11410,15 @@ xterm-addon-web-links@^0.4.0:
   resolved "https://registry.yarnpkg.com/xterm-addon-web-links/-/xterm-addon-web-links-0.4.0.tgz#265cbf8221b9b315d0a748e1323bee331cd5da03"
   integrity sha512-xv8GeiINmx0zENO9hf5k+5bnkaE8mRzF+OBAr9WeFq2eLaQSudioQSiT34M1ofKbzcdjSsKiZm19Rw3i4eXamg==
 
-xterm-addon-webgl@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/xterm-addon-webgl/-/xterm-addon-webgl-0.10.0.tgz#e99366fdc4cbd46b798a5e2fc114ecc19f9fd4b7"
-  integrity sha512-MJzyWie5yw+PH6p//fXlXzmsULLtpBo992EWEKl2uv5M5Zj9etTwfuutCUK7o98mr6itDl+vS/CYIMP68jCf8w==
+xterm-addon-webgl@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/xterm-addon-webgl/-/xterm-addon-webgl-0.11.0.tgz#9601ee21cbd092c35c5b01b6ba6ea63767209515"
+  integrity sha512-ohrvmACebnbYyTALbx6AC8GKqfK/heCeO9WWIProjoKatVYFTUD5m8KD6Mk2mbBZOOMgEwLajpcl0ujO2YH9Uw==
 
-xterm@^4.11.0:
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.11.0.tgz#d7dabc7af5299579e4663fedf2b3a179af9aaff9"
-  integrity sha512-NeJH909WTO2vth/ZlC0gkP3AGzupbvVHVlmtrpBw56/sGFXaF9bNdKgqKa3tf8qbGvXMzL2JhCcHVklqFztIRw==
+xterm@^4.12.0:
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.12.0.tgz#db09b425b4dcae5b96f8cbbaaa93b3bc60997ca9"
+  integrity sha512-K5mF/p3txUV18mjiZFlElagoHFpqXrm5OYHeoymeXSu8GG/nMaOO/+NRcNCwfdjzAbdQ5VLF32hEHiWWKKm0bw==
 
 "y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Allow using ligatures with WebGL renderer, thanks to https://github.com/xtermjs/xterm.js/pull/3286 in the [4.12.0](https://github.com/xtermjs/xterm.js/releases/tag/4.12.0) release.

Ligatures are now enabled by default along with the WebGL rendrerer.